### PR TITLE
Adds npx version to avoid global install of the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,15 @@ to revert!
 ## Running the Utility from the CLI
 
 ```
+npx js-to-ts-converter ./path/to/js/files
+```
+
+If you would prefer to install the CLI globally, do this:
+
+```
 npm install --global js-to-ts-converter
 
-js-to-ts-converter path/to/js/files
+js-to-ts-converter ./path/to/js/files
 ```
 
 


### PR DESCRIPTION
Using NPX allows you to run the CLI without globally installing it, which is what most people will want to do.

(BTW, thanks for this cool utility!)